### PR TITLE
Fix for Clara removed from play (not destroyed)

### DIFF
--- a/ClaraCloverfield/ClaraCloverfieldCardController.cs
+++ b/ClaraCloverfield/ClaraCloverfieldCardController.cs
@@ -34,8 +34,8 @@ namespace IntriguingComics.ClaraCloverfield
 
             //If this card is destroyed, the heroes lose.
 
-            AddTrigger((MoveCardAction moveCard) => moveCard.CardToMove == base.Card && moveCard.Destination.Name == LocationName.OutOfGame && moveCard.CardSource.Card.Identifier != "TheScionReserve", (MoveCardAction m) => HeroesLoseResponse(m), TriggerType.GameOver, TriggerTiming.After);
-            AddBeforeDestroyAction(HeroesLoseResponse);         
+            AddTrigger((MoveCardAction moveCard) => moveCard.CardToMove == base.Card && !moveCard.Destination.IsInPlay && moveCard.CardSource.Card.Identifier != "TheScionReserve", (MoveCardAction m) => HeroesLoseResponse(m), TriggerType.GameOver, TriggerTiming.Before);
+            AddBeforeDestroyAction(HeroesLoseResponse);
         }
 
 


### PR DESCRIPTION
This fix causes a game over if Clara is removed from play but not destroyed.